### PR TITLE
Added topmost and focus options for the default confirmation window

### DIFF
--- a/Ui/WinForms/Default.cs
+++ b/Ui/WinForms/Default.cs
@@ -33,24 +33,28 @@ namespace dlech.SshAgentLib.WinForms
     /// </summary>
     public static class Default
     {
+        /**
+        * MessageBox options for topmost and focus from:
+        * https://msdn.microsoft.com/en-us/library/windows/desktop/ms645505(v=vs.85).aspx
+        */
+        private const MessageBoxOptions TopMost = (MessageBoxOptions)0x00040000;
+        private const MessageBoxOptions SetForeground = (MessageBoxOptions)0x00010000;
+        private const MessageBoxOptions SystemModal = (MessageBoxOptions)0x00001000;
+
         public static bool ConfirmCallback(ISshKey key, Process process)
         {
+            
             var programName = Strings.askConfirmKeyUnknownProcess;
             if (process != null) {
                 programName = string.Format("{0} ({1})", process.MainWindowTitle,
                     process.ProcessName);
             }
 
-            /**
-             * MessageBox options for topmost and focus from:
-             * https://msdn.microsoft.com/en-us/library/windows/desktop/ms645505(v=vs.85).aspx
-             */
-
             DialogResult result = MessageBox.Show(
                 string.Format(Strings.askConfirmKey, programName, key.Comment,
                 key.GetMD5Fingerprint().ToHexString()), Util.AssemblyTitle,
                 MessageBoxButtons.YesNo, MessageBoxIcon.Question,
-                MessageBoxDefaultButton.Button2, (MessageBoxOptions)0x51000
+                MessageBoxDefaultButton.Button2, TopMost | SetForeground | SystemModal
             );
             return (result == DialogResult.Yes);
         }

--- a/Ui/WinForms/Default.cs
+++ b/Ui/WinForms/Default.cs
@@ -43,7 +43,6 @@ namespace dlech.SshAgentLib.WinForms
 
         public static bool ConfirmCallback(ISshKey key, Process process)
         {
-            
             var programName = Strings.askConfirmKeyUnknownProcess;
             if (process != null) {
                 programName = string.Format("{0} ({1})", process.MainWindowTitle,

--- a/Ui/WinForms/Default.cs
+++ b/Ui/WinForms/Default.cs
@@ -40,11 +40,17 @@ namespace dlech.SshAgentLib.WinForms
                 programName = string.Format("{0} ({1})", process.MainWindowTitle,
                     process.ProcessName);
             }
-            var result = MessageBox.Show(
+
+            /**
+             * MessageBox options for topmost and focus from:
+             * https://msdn.microsoft.com/en-us/library/windows/desktop/ms645505(v=vs.85).aspx
+             */
+
+            DialogResult result = MessageBox.Show(
                 string.Format(Strings.askConfirmKey, programName, key.Comment,
                 key.GetMD5Fingerprint().ToHexString()), Util.AssemblyTitle,
                 MessageBoxButtons.YesNo, MessageBoxIcon.Question,
-                MessageBoxDefaultButton.Button2
+                MessageBoxDefaultButton.Button2, (MessageBoxOptions)0x51000
             );
             return (result == DialogResult.Yes);
         }


### PR DESCRIPTION
Using a hack in the MessageBox options, allow the confirmation window to become system modal (always on top), and to take the focus from the calling application.

Tested only on Win7Pro
