### PR TITLE
Overhaul WindowsOpenSshPipe to use asynchronous connections

### DIFF
--- a/SshAgentLib/WindowsOpenSshPipe.cs
+++ b/SshAgentLib/WindowsOpenSshPipe.cs
@@ -34,12 +34,12 @@ namespace dlech.SshAgentLib
 {
   public class WindowsOpenSshPipe : IDisposable
   {
-    const string agentPipeId = "openssh-ssh-agent";
-    const int receiveBufferSize = 5 * 1024;
+    private const string agentPipeId = "openssh-ssh-agent";
+    private const int receiveBufferSize = 5 * 1024;
 
-    static uint threadId;
+    private static uint threadId;
 
-    NamedPipeServerStream listeningServer;
+    private NamedPipeServerStream listeningServer;
 
 
     public delegate void ConnectionHandlerFunc(Stream stream, Process process);
@@ -58,9 +58,9 @@ namespace dlech.SshAgentLib
     }
 
     [DllImport("kernel32.dll", SetLastError = true)]
-    static extern bool GetNamedPipeClientProcessId(IntPtr Pipe, out uint ClientProcessId);
+    private static extern bool GetNamedPipeClientProcessId(IntPtr Pipe, out uint ClientProcessId);
 
-    void listenerThread()
+    private void listenerThread()
     {
       try {
         while (true) {
@@ -81,7 +81,7 @@ namespace dlech.SshAgentLib
       }
     }
 
-    void connectionThread(object obj)
+    private void connectionThread(object obj)
     {
       try {
         var server = obj as NamedPipeServerStream;
@@ -106,7 +106,7 @@ namespace dlech.SshAgentLib
       GC.SuppressFinalize(this);
     }
 
-    void Dispose(bool disposing)
+    protected virtual void Dispose(bool disposing)
     {
       if (disposing) {
         if (listeningServer != null) {

--- a/SshAgentLib/WindowsOpenSshPipe.cs
+++ b/SshAgentLib/WindowsOpenSshPipe.cs
@@ -42,11 +42,11 @@ namespace dlech.SshAgentLib
     static uint threadId = 0;
 
     NamedPipeServerStream listeningServer;
-    
+
 
     public delegate void ConnectionHandlerFunc(Stream stream, Process process);
     public ConnectionHandlerFunc ConnectionHandler { get; set; }
-    
+
     public WindowsOpenSshPipe()
     {
       if (File.Exists(string.Format("//./pipe/{0}", agentPipeId))) {
@@ -58,7 +58,7 @@ namespace dlech.SshAgentLib
       };
       thread.Start();
     }
-    
+
     [DllImport("kernel32.dll", SetLastError = true)]
     static extern bool GetNamedPipeClientProcessId(IntPtr Pipe, out long ClientProcessId);
 
@@ -102,7 +102,7 @@ namespace dlech.SshAgentLib
         // TODO: add event to notify when there is a problem
       }
     }
-    
+
     public void Dispose()
     {
       Dispose(true);


### PR DESCRIPTION
The existing implementation uses synchronous blocking APIs for handling client connections to the named pipe. This PR overhauls the implementation to use asynchronous non-blocking named pipes, while also fixing several issues with the implementation.

If Windows OpenSSH agent support is enabled and subsequently disabled, the agent named pipe will not be closed. This is a (minor) security vulnerability as KeeAgent will continue to serve SSH agent responses when the functionality is meant to be disabled.

There's two reasons why this happens:
- While `Dispose()` is called on the class, a new server is started by `listenerThread()`. Also, thread objects aren't garbage collected, so this won't eventually fix itself when the garbage collector runs.
- The call to `WaitForConnection()` is a blocking call. That extends to the `Dispose()` call, which will be blocked until a connection to the pipe is made. It'll then be immediately closed, so the client won't likely get any response, but per above a new named pipe is created.

A side-effect of the latter is that re-enabling the feature in the same KeePass process will never work, as the named pipe path will always be still in use. An error message to that effect is shown to the user.

Switching to asynchronous connections helps solve both of these issues. Instead of spawning threads we leverage the .NET thread pool, and the `Dispose()` logic has been improved to ensure the listening server will be reliably closed if the feature is disabled. Some more explicit exception handling and minimal logging for debugging purposes has also been added.

This PR fixes https://github.com/dlech/KeeAgent/issues/226 and at least the error in the initial report in https://github.com/dlech/KeeAgent/issues/246.