### PR TITLE
added support for ppkv3 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ SshAgentLibTests/SshAgentLibTests.csproj.VisualState.xml
 
 # Nuget
 packages/
+.idea/

--- a/SshAgentLib/KeyFormatter.cs
+++ b/SshAgentLib/KeyFormatter.cs
@@ -148,7 +148,7 @@ namespace dlech.SshAgentLib
     public static KeyFormatter GetFormatter (string firstLine)
     {
       // PuTTY Private key format
-      var ppkRegex = new Regex (PpkFormatter.puttyUserKeyFileKey+"("+PpkFormatter.legalVersions+")");
+      var ppkRegex = new Regex (PpkFormatter.puttyUserKeyFileKey+"("+PpkFormatter.cLegalVersions+")");
       // OpenSSH private key format
       var pemPrivateKeyRegex = new Regex ("-----BEGIN .* PRIVATE KEY-----");
 

--- a/SshAgentLib/KeyFormatter.cs
+++ b/SshAgentLib/KeyFormatter.cs
@@ -148,13 +148,13 @@ namespace dlech.SshAgentLib
     public static KeyFormatter GetFormatter (string firstLine)
     {
       // PuTTY Private key format
-      var ppkRegex = new Regex ("PuTTY-User-Key-File-[12]");
+      var ppkRegex = new Regex (PpkFormatter.puttyUserKeyFileKey+"("+PpkFormatter.legalVersions+")");
       // OpenSSH private key format
       var pemPrivateKeyRegex = new Regex ("-----BEGIN .* PRIVATE KEY-----");
 
       if (!string.IsNullOrWhiteSpace (firstLine)) {
         if (ppkRegex.IsMatch (firstLine)) {
-          return new PpkFormatter ();
+          return new PpkFormatter();
         } else if (OpensshPrivateKeyFormatter.MARK_BEGIN == firstLine) {
           return new OpensshPrivateKeyFormatter();
         } else if (pemPrivateKeyRegex.IsMatch(firstLine)) {

--- a/SshAgentLib/KeyFormatter.cs
+++ b/SshAgentLib/KeyFormatter.cs
@@ -147,20 +147,18 @@ namespace dlech.SshAgentLib
     /// </exception>
     public static KeyFormatter GetFormatter (string firstLine)
     {
-      // PuTTY Private key format
-      var ppkRegex = new Regex (PpkFormatter.puttyUserKeyFileKey+"("+PpkFormatter.cLegalVersions+")");
       // OpenSSH private key format
       var pemPrivateKeyRegex = new Regex ("-----BEGIN .* PRIVATE KEY-----");
 
-      if (!string.IsNullOrWhiteSpace (firstLine)) {
-        if (ppkRegex.IsMatch (firstLine)) {
+      if (!string.IsNullOrWhiteSpace(firstLine)) {
+        if (PpkFormatter.rePuttyUserKeyFile.IsMatch(firstLine)) {
           return new PpkFormatter();
         } else if (OpensshPrivateKeyFormatter.MARK_BEGIN == firstLine) {
           return new OpensshPrivateKeyFormatter();
         } else if (pemPrivateKeyRegex.IsMatch(firstLine)) {
-          return new PemKeyFormatter ();
+          return new PemKeyFormatter();
         } else if (Ssh1KeyFormatter.FILE_HEADER_LINE == firstLine) {
-          return new Ssh1KeyFormatter ();
+          return new Ssh1KeyFormatter();
         }
       }
       throw new KeyFormatterException ("Unknown file format");

--- a/SshAgentLib/PpkFormatter.cs
+++ b/SshAgentLib/PpkFormatter.cs
@@ -374,7 +374,7 @@ namespace dlech.SshAgentLib
         m = MatchOrThrow(rePrivateMACorHash, line);
         if (!m.Groups[1].Value.EndsWith("MAC")) {
           fileData.isHMAC = false;
-          if (m.Groups[1].Value.EndsWith("Hash") || fileData.ppkFileVersion != Version.V1) {
+          if ((fileData.ppkFileVersion == Version.V1 && !m.Groups[1].Value.EndsWith("Hash")) || fileData.ppkFileVersion != Version.V1) {
             throw new PpkFormatterException(PpkFormatterException.PpkErrorType.FileFormat,
                                             rePrivateMACorHash + " expected");
           }

--- a/SshAgentLib/PpkFormatter.cs
+++ b/SshAgentLib/PpkFormatter.cs
@@ -310,18 +310,6 @@ namespace dlech.SshAgentLib
           throw new PpkFormatterException(PpkFormatterException.PpkErrorType.PublicKeyEncryption);
         }
 
-        SecureString tmp = GetPassphraseCallbackMethod?.Invoke(fileData.comment);
-        if (fileData.privateKeyAlgorithm == PrivateKeyAlgorithm.None && tmp != null)
-          throw new PpkFormatterException(PpkFormatterException.PpkErrorType.NotEncrypted,
-            "Remove the passphrase or encrypt the private key");
-        if (fileData.privateKeyAlgorithm != PrivateKeyAlgorithm.None) {
-          if (GetPassphraseCallbackMethod == null) throw new CallbackNullException();
-          if (tmp == null)
-            throw new PpkFormatterException(PpkFormatterException.PpkErrorType.MissingPassphrase,
-            "No passphrase for encrypted private key");
-        }
-        fileData.passphrase = tmp;
-
         /* read private key encryption algorithm type */
         line = reader.ReadLine();
         m = MatchOrThrow(rePrivateKeyEncryption, line);
@@ -398,6 +386,19 @@ namespace dlech.SshAgentLib
 
 
         /* get passphrase and decrypt private key if required */
+        SecureString tmp = GetPassphraseCallbackMethod?.Invoke(fileData.comment);
+        if (tmp != null && tmp.Length == 0) tmp = null;
+        if (fileData.privateKeyAlgorithm == PrivateKeyAlgorithm.None && tmp != null)
+          throw new PpkFormatterException(PpkFormatterException.PpkErrorType.NotEncrypted,
+            "Remove the passphrase or encrypt the private key");
+        if (fileData.privateKeyAlgorithm != PrivateKeyAlgorithm.None) {
+          if (GetPassphraseCallbackMethod == null) throw new CallbackNullException();
+          if (tmp == null)
+            throw new PpkFormatterException(PpkFormatterException.PpkErrorType.MissingPassphrase,
+              "No passphrase for encrypted private key");
+        }
+        fileData.passphrase = tmp;
+
 
         Aes cipher;
         HashAlgorithm mac;

--- a/SshAgentLib/PpkFormatter.cs
+++ b/SshAgentLib/PpkFormatter.cs
@@ -383,7 +383,7 @@ namespace dlech.SshAgentLib
         Aes cipher;
         HashAlgorithm mac;
         fileData.passphrase = GetPassphraseCallbackMethod.Invoke(fileData.comment);
-        CreateKeyMaterial(fileData, out cipher, out mac);
+        DeriveKeys(fileData, out cipher, out mac);
 
         DecryptPrivateKey(ref fileData, cipher);
         VerifyIntegrity(fileData, mac);
@@ -430,7 +430,7 @@ namespace dlech.SshAgentLib
       cipher.Clear();
     }
 
-    private static void CreateKeyMaterial(FileData fileData, out Aes cipher, out HashAlgorithm mac)
+    private static void DeriveKeys(FileData fileData, out Aes cipher, out HashAlgorithm mac)
     {
       switch (fileData.ppkFileVersion) {
         case Version.V1:

--- a/SshAgentLib/PpkFormatter.cs
+++ b/SshAgentLib/PpkFormatter.cs
@@ -45,7 +45,7 @@ namespace dlech.SshAgentLib
   /// </summary>
   public class PpkFormatter : KeyFormatter
   {
-    public static readonly string legalVersions = string.Join("|", from v in Enum.GetNames(typeof(Version)) select v.Substring(1));
+    public static readonly string cLegalVersions = Util.EnumJoin<Version>("|").Replace("V", "");
 
     #region -- Constants --
 
@@ -289,7 +289,7 @@ namespace dlech.SshAgentLib
       try {
         /* read file version */
         line = reader.ReadLine();
-        m = MatchOrThrow(line, "^"+puttyUserKeyFileKey+"("+legalVersions+"): ?(.*)$");
+        m = MatchOrThrow(line, "^"+puttyUserKeyFileKey+"("+cLegalVersions+"): ?(.*)$");
 
         fileData.ppkFileVersion = (Version) Enum.Parse(typeof(Version), "V"+m.Groups[1].Value);
         if (fileData.ppkFileVersion == Version.V1) {
@@ -325,7 +325,7 @@ namespace dlech.SshAgentLib
         /* key derivation function */
         if (fileData.privateKeyAlgorithm != PrivateKeyAlgorithm.None) {
           line = reader.ReadLine();
-          string legal = string.Join("|", Enum.GetNames(typeof(KeyDerivation)));
+          string legal = Util.EnumJoin<KeyDerivation>("|");
           m = MatchOrThrow(line, "^"+keyDeriviationKey+": ?("+legal+")$");
 
           fileData.kdfAlgorithm = (KeyDerivation) Enum.Parse(typeof(KeyDerivation), m.Groups[1].Value);

--- a/SshAgentLib/PpkFormatter.cs
+++ b/SshAgentLib/PpkFormatter.cs
@@ -76,6 +76,32 @@ namespace dlech.SshAgentLib
     private const string publicKeyLinesKey = "Public-Lines";
 
     /// <summary>
+    /// Key that indicates the key derivation algorithm
+    /// </summary>
+    private const string keyDeriviationKey = "Key-Derivation";
+
+    /// <summary>
+    /// Argon2 memory
+    /// </summary>
+    private const string argonMemoryKey = "Argon2-Memory";
+
+    /// <summary>
+    /// Argon2 iterations
+    /// </summary>
+    private const string argonPassesKey = "Argon2-Passes";
+
+    /// <summary>
+    /// Argon2 parallelism
+    /// </summary>
+    private const string argonParallelismKey = "Argon2-Parallelism";
+
+    /// <summary>
+    /// Argon2 salt represented as a hex encoded byte[] is the ppk file
+    /// </summary>
+    private const string argonSaltKey = "Argon2-Salt";
+
+
+    /// <summary>
     /// Key that indicates that the private key follows on the next line
     /// and the length of the key in lines
     /// </summary>

--- a/SshAgentLib/PpkFormatter.cs
+++ b/SshAgentLib/PpkFormatter.cs
@@ -652,38 +652,6 @@ namespace dlech.SshAgentLib
       }
     }
 
-    // public static string GetName(this PpkFormatter.Version aVersion)
-    // {
-    //   switch (aVersion) {
-    //     case PpkFormatter.Version.V1:
-    //       return "1";
-    //     case PpkFormatter.Version.V2:
-    //       return "2";
-    //     case PpkFormatter.Version.V3:
-    //       return "3";
-    //     default:
-    //       Debug.Fail("Unknown version");
-    //       throw new Exception("Unknown version");
-    //   }
-    // }
-    //
-    // public static bool TryParseVersion(this string text, ref PpkFormatter.Version version)
-    // {
-    //   switch (text) {
-    //     case "1":
-    //       version = PpkFormatter.Version.V1;
-    //       return true;
-    //     case "2":
-    //       version = PpkFormatter.Version.V2;
-    //       return true;
-    //     case "3":
-    //       version = PpkFormatter.Version.V3;
-    //       return true;
-    //     default:
-    //       return false;
-    //   }
-    // }
-
     public static bool TryParsePublicKeyAlgorithm(this string text, ref PublicKeyAlgorithm algo)
     {
       switch (text) {

--- a/SshAgentLib/PpkFormatter.cs
+++ b/SshAgentLib/PpkFormatter.cs
@@ -278,9 +278,7 @@ namespace dlech.SshAgentLib
             PpkFormatterException.PpkErrorType.FileFormat, regex);
         fileData.ppkFileVersion = (Version) Enum.Parse(typeof(Version), "V"+m.Groups[1].Value);
         if (fileData.ppkFileVersion == Version.V1) {
-          if (WarnOldFileFormatCallbackMethod != null) {
-            WarnOldFileFormatCallbackMethod.Invoke();
-          }
+          WarnOldFileFormatCallbackMethod?.Invoke();
         }
 
         /* read public key encryption algorithm type */

--- a/SshAgentLib/PpkFormatter.cs
+++ b/SshAgentLib/PpkFormatter.cs
@@ -291,7 +291,7 @@ namespace dlech.SshAgentLib
         line = reader.ReadLine();
         m = MatchOrThrow(line, "^"+puttyUserKeyFileKey+"("+cLegalVersions+"): ?(.*)$");
 
-        fileData.ppkFileVersion = (Version) Enum.Parse(typeof(Version), "V"+m.Groups[1].Value);
+        fileData.ppkFileVersion = Util.EnumParse<Version>("V"+m.Groups[1].Value);
         if (fileData.ppkFileVersion == Version.V1) {
           WarnOldFileFormatCallbackMethod?.Invoke();
         }
@@ -328,7 +328,7 @@ namespace dlech.SshAgentLib
           string legal = Util.EnumJoin<KeyDerivation>("|");
           m = MatchOrThrow(line, "^"+keyDeriviationKey+": ?("+legal+")$");
 
-          fileData.kdfAlgorithm = (KeyDerivation) Enum.Parse(typeof(KeyDerivation), m.Groups[1].Value);
+          fileData.kdfAlgorithm = Util.EnumParse<KeyDerivation>(m.Groups[1].Value);
 
           string kdfName = Enum.GetName(typeof(KeyDerivation), fileData.kdfAlgorithm);
           fileData.kdfParameters = new Dictionary<string, object>();

--- a/SshAgentLib/PpkFormatter.cs
+++ b/SshAgentLib/PpkFormatter.cs
@@ -70,13 +70,13 @@ namespace dlech.SshAgentLib
     private const string commentKey = "Comment";
 
     /// <summary>
-    /// Key that indicates that the public key follows on the next line 
+    /// Key that indicates that the public key follows on the next line
     /// and the length of the key in lines
     /// </summary>
     private const string publicKeyLinesKey = "Public-Lines";
 
     /// <summary>
-    /// Key that indicates that the private key follows on the next line 
+    /// Key that indicates that the private key follows on the next line
     /// and the length of the key in lines
     /// </summary>
     private const string privateKeyLinesKey = "Private-Lines";
@@ -109,7 +109,8 @@ namespace dlech.SshAgentLib
     internal enum Version
     {
       V1,
-      V2
+      V2,
+      V3
     }
 
     /// <summary>
@@ -132,7 +133,7 @@ namespace dlech.SshAgentLib
 
       /// <summary>
       /// File format version (one of FileVersions members)
-      /// Callers of this method should warn user 
+      /// Callers of this method should warn user
       /// that version 1 has security issue and should not be used
       /// </summary>
       public Version ppkFileVersion;
@@ -626,6 +627,8 @@ namespace dlech.SshAgentLib
           return "1";
         case PpkFormatter.Version.V2:
           return "2";
+        case PpkFormatter.Version.V3:
+          return "3";
         default:
           Debug.Fail("Unknown version");
           throw new Exception("Unknown version");
@@ -640,6 +643,9 @@ namespace dlech.SshAgentLib
           return true;
         case "2":
           version = PpkFormatter.Version.V2;
+          return true;
+        case "3":
+          version = PpkFormatter.Version.V3;
           return true;
         default:
           return false;

--- a/SshAgentLib/PpkFormatterException.cs
+++ b/SshAgentLib/PpkFormatterException.cs
@@ -63,6 +63,16 @@ namespace dlech.SshAgentLib
       BadPassphrase,
 
       /// <summary>
+      /// Private key is encrypted, but there is no passphrase supplied
+      /// </summary>
+      MissingPassphrase,
+
+      /// <summary>
+      /// A passphrase is supplied when the private key is unprotected
+      /// </summary>
+      NotEncrypted,
+
+      /// <summary>
       /// File is corrupted or has been tampered with
       /// </summary>
       FileCorrupt
@@ -83,7 +93,7 @@ namespace dlech.SshAgentLib
 
     public PpkFormatterException(PpkErrorType err, string message,
       Exception innerException)
-      : base(message, innerException) 
+      : base(message, innerException)
     {
       this.PpkError = err;
     }

--- a/SshAgentLib/SshAgentLib.csproj
+++ b/SshAgentLib/SshAgentLib.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>dlech.SshAgentLib</RootNamespace>
     <AssemblyName>SshAgentLib</AssemblyName>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>True</DebugSymbols>

--- a/SshAgentLib/SshAgentLib.csproj
+++ b/SshAgentLib/SshAgentLib.csproj
@@ -119,10 +119,24 @@
     <Reference Include="Chaos.NaCl, Version=0.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\dlech.Chaos.NaCl.0.1.0.0\lib\net40\Chaos.NaCl.dll</HintPath>
     </Reference>
+    <Reference Include="Konscious.Security.Cryptography.Argon2, Version=1.2.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\Konscious.Security.Cryptography.Argon2.1.2.1\lib\net46\Konscious.Security.Cryptography.Argon2.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Konscious.Security.Cryptography.Blake2, Version=1.0.9.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\Konscious.Security.Cryptography.Blake2.1.0.9\lib\net46\Konscious.Security.Cryptography.Blake2.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Net" />

--- a/SshAgentLib/Util.cs
+++ b/SshAgentLib/Util.cs
@@ -64,6 +64,11 @@ namespace dlech.SshAgentLib
       return string.Join(separator, Enum.GetNames(typeof(T)));
     }
 
+    public static T EnumParse<T>(string value)
+    {
+      return (T) Enum.Parse(typeof(T), value);
+    }
+
     /// <summary>
     /// Adds Agent.KeyConstraintType.SSH_AGENT_CONSTRAIN_LIFETIME constraint to key
     /// </summary>

--- a/SshAgentLib/Util.cs
+++ b/SshAgentLib/Util.cs
@@ -54,6 +54,11 @@ namespace dlech.SshAgentLib
       keyCollection.Add(constraint);
     }
 
+    public static string EnumGetName(Enum value)
+    {
+      return Enum.GetName(value.GetType(), value);
+    }
+
     /// <summary>
     /// Adds Agent.KeyConstraintType.SSH_AGENT_CONSTRAIN_LIFETIME constraint to key
     /// </summary>

--- a/SshAgentLib/Util.cs
+++ b/SshAgentLib/Util.cs
@@ -59,6 +59,11 @@ namespace dlech.SshAgentLib
       return Enum.GetName(value.GetType(), value);
     }
 
+    public static string EnumJoin<T>(string separator)
+    {
+      return string.Join(separator, Enum.GetNames(typeof(T)));
+    }
+
     /// <summary>
     /// Adds Agent.KeyConstraintType.SSH_AGENT_CONSTRAIN_LIFETIME constraint to key
     /// </summary>

--- a/SshAgentLib/packages.config
+++ b/SshAgentLib/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Konscious.Security.Cryptography.Argon2" version="1.2.1" targetFramework="net46" />
+  <package id="Konscious.Security.Cryptography.Blake2" version="1.0.9" targetFramework="net46" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net46" />
   <package id="dlech.Chaos.NaCl" version="0.1.0.0" targetFramework="net40" />
   <package id="Mono.Posix" version="4.0.0.0" targetFramework="net4" />
   <package id="Portable.BouncyCastle" version="1.8.1.3" targetFramework="net40" />

--- a/SshAgentLibTests/PpkFormatterTest.cs
+++ b/SshAgentLibTests/PpkFormatterTest.cs
@@ -470,6 +470,21 @@ namespace dlech.SshAgentLibTests
       Assert.NotNull(target);
       Assert.IsInstanceOf<SshKey>(target);
     }
+
+    [Test]
+    public void Ppkv3FileParseDataNonAsciiPassphraseTest()
+    {
+      ISshKey target;
+      // const string passphrase = "PageantSharp";
+      const string passphrase = "Ŧéşť";
+
+      PpkFormatter formatter = new PpkFormatter();
+      formatter.GetPassphraseCallbackMethod = GetPassphrase(passphrase);
+      var path = Path.Combine(DllDirectory, "../../Resources/ssh2-rsa-v3-non-ascii-passphrase.ppk");
+      target = formatter.DeserializeFile(path);
+      Assert.NotNull(target);
+      Assert.IsInstanceOf<SshKey>(target);
+    }
   }
 }
 

--- a/SshAgentLibTests/Resources/ssh2-rsa-v3-no-passphrase.ppk
+++ b/SshAgentLibTests/Resources/ssh2-rsa-v3-no-passphrase.ppk
@@ -1,0 +1,18 @@
+PuTTY-User-Key-File-3: ssh-rsa
+Encryption: none
+Comment: PageantSharp test: SSH2-RSA, no passphrase, v3
+Public-Lines: 4
+AAAAB3NzaC1yc2EAAAABJQAAAIEAvpwLqhmHYAipvnbQeFEzC7kSTdOCpH5XP9rT
+lwScQ5n6Br1DDGIg7tSOBCbralX+0U7NClrcUkueydXRqXEf1rX26o4EcrZ+v1z/
+pgu7dbOyHKK0LczCx/IHBm8jrpzrJeB0rg+0ym7XgEcGYgdRj7wFo93PEtx1T4kF
+gNLsE3k=
+Private-Lines: 8
+AAAAgE1GLj4KWXn1rJlSwzeyN0nxFUIlUKONKkpRy2a8rg2RczMqIhnG6sGwHeYB
+8LxoDVvGABj0ZyhIK53u5kuckF1DiWEcq3IwGIIZqR6JOwMucjbV1pvvzTz3QpUE
+fJ+Hj4tHaI7A124D0b/paUmBxOUgeVYXuMls5GZbcl2ApKNdAAAAQQDkXflDxnVr
+EXrXAjK+kug3PDdGOPLVPTQRDGwNbuHhSXdVTKAsBdfp9LJZqDzW4LnWhjebeGbj
+Kr1ef2VU7cn1AAAAQQDVrHk2uTj27Iwkj31P/WOBXCrmnQ+oAspL3uaJ1rqxg9+F
+rq3Dva/y7n0UBRqJ8Y+mdkKQW6oO0usEsEXrVxz1AAAAQF3U8ibnexxDTxhUZdw5
+4nzukrnamPWqbZf2RyvQAMA0vw6uW1YNcN6qJxAkt7K5rLg9fsV2ft1FFBcPy+C+
+BDw=
+Private-MAC: e4c8f05bd6ffd1e9d52b9adbb2b4052af55a532161c4edaf18b153be6e2f1410

--- a/SshAgentLibTests/Resources/ssh2-rsa-v3-non-ascii-passphrase.ppk
+++ b/SshAgentLibTests/Resources/ssh2-rsa-v3-non-ascii-passphrase.ppk
@@ -1,0 +1,23 @@
+PuTTY-User-Key-File-3: ssh-rsa
+Encryption: aes256-cbc
+Comment: PageantSharp test: SSH2-RSA, no passphrase, v3
+Public-Lines: 4
+AAAAB3NzaC1yc2EAAAABJQAAAIEAvpwLqhmHYAipvnbQeFEzC7kSTdOCpH5XP9rT
+lwScQ5n6Br1DDGIg7tSOBCbralX+0U7NClrcUkueydXRqXEf1rX26o4EcrZ+v1z/
+pgu7dbOyHKK0LczCx/IHBm8jrpzrJeB0rg+0ym7XgEcGYgdRj7wFo93PEtx1T4kF
+gNLsE3k=
+Key-Derivation: Argon2id
+Argon2-Memory: 8192
+Argon2-Passes: 21
+Argon2-Parallelism: 1
+Argon2-Salt: 05d409c060f4ac9ecdc7ab4b270bd5dd
+Private-Lines: 8
+8Bjx7GoAmK9czattBbx8l1+Bg/UyTeUVY9p3C0XsuxlD0x3v2VM2u6+lqL1/24/I
+WuBjD2wXNpj1nBxvQUg73ve4l/I91rYAKBrn/fVZsFWd5mnCx9qePbS0TeN/x5VU
+v3NSWYCdfRotGGDHEL5sKMXFvX7c7ceEJyOyzXPjfuFLAHR6muFRGebFwgMsn//N
+KXd3bzQEiAnkH6r0uUxGXIgaMu8qcrQRYO6gDmyN0GXXBh8gr3KMtsCQOdeh3M+Z
+QJCZwopFTx7FT1ot28aWYpAviYY3+vgAyxaBsMyw5aRzSogltVclk+mDWJo0qOnV
++09DBtSBhgXMrWV2qONhJeK7BGrkeg2UIoVBwxxmqvdDtKcRYpWpVYk4VEhusyKB
+lfRQPHoBKTRdEcgiMDULL9eGCX+V3hrcQx4X0DaFWoPw/ZilQCAATFY5s3TZ04Bg
+vCST5LJaHVKTVVDr2oBcSw==
+Private-MAC: 731222ce5c0745cc618740183718ae8b2600e22be5419c91f59b7422f7ad1501

--- a/SshAgentLibTests/Resources/ssh2-rsa-v3.ppk
+++ b/SshAgentLibTests/Resources/ssh2-rsa-v3.ppk
@@ -1,0 +1,23 @@
+PuTTY-User-Key-File-3: ssh-rsa
+Encryption: aes256-cbc
+Comment: PageantSharp test: SSH2-RSA, with passphrase, v3
+Public-Lines: 4
+AAAAB3NzaC1yc2EAAAABJQAAAIEAvpwLqhmHYAipvnbQeFEzC7kSTdOCpH5XP9rT
+lwScQ5n6Br1DDGIg7tSOBCbralX+0U7NClrcUkueydXRqXEf1rX26o4EcrZ+v1z/
+pgu7dbOyHKK0LczCx/IHBm8jrpzrJeB0rg+0ym7XgEcGYgdRj7wFo93PEtx1T4kF
+gNLsE3k=
+Key-Derivation: Argon2id
+Argon2-Memory: 8192
+Argon2-Passes: 21
+Argon2-Parallelism: 1
+Argon2-Salt: 65e2c7d47f08726bb1845b4e33e760be
+Private-Lines: 8
+Vh4S7o8nhLwBPPLA8xpx288Q+/O7QY5gM886GMyG1S4FTjRZYoWlxvA91RowoF4i
+nekrr2bxSHSHA/gSLIG7HzIJDT2KPZlIOA0nvETsJDGizfckhV69pcU6u9sjs8f6
+1rtViIVpWIJeraPvwjF5fceaomrm89bU0XsC0pTE6vJU0stiihSCsiFWDgV6d8F/
+9p2TvqsXYEiQT5la+q8RSjo1mNZ4dRaZ+Tepz8RxEWwiXTclk4kSXwUCk0TpgEeX
+wPBr20pZJcAwRD/NeRiB/YylNUEDxnsu51xPHs6sl242H7AjNx3NaF7QGgTF7SRk
+a9s/6so6wfVoWWxF3NvJnc74WryFTWf1C3JyeXCg15Xth90onoRH+BEqs+JNnGip
+A4ixmRcQO3eNsUboNzWACYrADhqxsNGKQ+hJisUvhf0eoCsxUDHyBA1VbmC9wyFV
+hqH2o1q68u0iu1baPz+Gdg==
+Private-MAC: 94b7fd4f3322e3afc7dc7cfa6829e7e8f2236bc90b21906bd466fc8f4346606b

--- a/SshAgentLibTests/SshAgentLibTests.csproj
+++ b/SshAgentLibTests/SshAgentLibTests.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>dlech.SshAgentLibTests</RootNamespace>
     <AssemblyName>SshAgentLibTests</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Ui/Common/SshAgentLib.Ui.Common.csproj
+++ b/Ui/Common/SshAgentLib.Ui.Common.csproj
@@ -9,6 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>dlech.SshAgentLib.Ui.Common</RootNamespace>
     <AssemblyName>SshAgentLib.Ui.Common</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Ui/Gtk/SshAgentLib.Ui.GTK.csproj
+++ b/Ui/Gtk/SshAgentLib.Ui.GTK.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>SshAgentLib.GTK</RootNamespace>
     <AssemblyName>SshAgentLib.GTK</AssemblyName>
     <SynchReleaseVersion>False</SynchReleaseVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Ui/Qt.Demo/SshAgentLib.Ui.Qt.Demo.csproj
+++ b/Ui/Qt.Demo/SshAgentLib.Ui.Qt.Demo.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>SshAgentLib.Ui.Qt.Demo</RootNamespace>
     <AssemblyName>SshAgentLib.Ui.Qt.Demo</AssemblyName>
     <StartupObject>dlech.SshAgentLib.Ui.QtAgent.Program</StartupObject>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Ui/Qt/SshAgentLib.Ui.Qt.csproj
+++ b/Ui/Qt/SshAgentLib.Ui.Qt.csproj
@@ -10,6 +10,7 @@
     <RootNamespace>dlech.SshAgentLib.Ui.QtAgent</RootNamespace>
     <AssemblyName>SshAgentLib.Qt</AssemblyName>
     <SynchReleaseVersion>False</SynchReleaseVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Ui/WinForms/SshAgentLib.Ui.WinForms.csproj
+++ b/Ui/WinForms/SshAgentLib.Ui.WinForms.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>dlech.SshAgentLib.WinForms</RootNamespace>
     <AssemblyName>SshAgentLib.WinForms</AssemblyName>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>


### PR DESCRIPTION
The biggest compatibility break that I made was refusing to load an unprotected private key if a non-empty/non-null passphrase is supplied.

- use regex to match lines and extract information rather than split and check
- the private key encryption and whether a passphrase is supplied or not must match up
- added 2 more types to the enum PpkError
- an empty passphrase is translated into a null passphrase
- a single function derives and initializes the cipher engine and hmac which will make generating keys easier to implement
- legal ppk version information is derived exclusively from the Version enum now
