### PR TITLE
Always prefer provided public key over included one

### DIFF
--- a/SshAgentLib/Keys/PuttyPrivateKey.cs
+++ b/SshAgentLib/Keys/PuttyPrivateKey.cs
@@ -84,7 +84,7 @@ namespace SshAgentLib.Keys
 
         private static readonly char[] headerDelimeter = { ':' };
 
-        public static SshPrivateKey Read(Stream stream)
+        public static SshPrivateKey Read(Stream stream, SshPublicKey publicKey)
         {
             if (stream == null)
             {
@@ -115,7 +115,8 @@ namespace SshAgentLib.Keys
 
             var publicKeyBlob = Convert.FromBase64String(publicKeyString.ToString());
 
-            var publicKey = new SshPublicKey(publicKeyBlob, comment);
+            // if a separate public key has been provided, keep it
+            publicKey = publicKey ?? new SshPublicKey(publicKeyBlob, comment);
 
             var argon2Parameter = new Argon2.Parameters();
 

--- a/SshAgentLib/Keys/SshPrivateKey.cs
+++ b/SshAgentLib/Keys/SshPrivateKey.cs
@@ -116,7 +116,9 @@ namespace SshAgentLib.Keys
         /// <param name="publicKey">
         /// A public key that matches the private key. This is required for legacy
         /// private key file formats that do not contain public key information and
-        /// ignored for private key file formats that already include the public key.
+        /// encrypted private key files which only reveal the public key information
+        /// after decryption. If this parameter is provided it will be preferred over
+        /// public key information already included in a private key file.
         /// </param>
         /// <returns>
         /// An object containing the information read from the file.
@@ -146,7 +148,7 @@ namespace SshAgentLib.Keys
 
                 if (PuttyPrivateKey.FirstLineMatches(firstLine))
                 {
-                    return PuttyPrivateKey.Read(reader.BaseStream);
+                    return PuttyPrivateKey.Read(reader.BaseStream, publicKey);
                 }
 
                 if (PemPrivateKey.FirstLineMatches(firstLine))
@@ -161,7 +163,7 @@ namespace SshAgentLib.Keys
 
                 if (OpensshPrivateKey.FirstLineMatches(firstLine))
                 {
-                    return OpensshPrivateKey.Read(reader.BaseStream);
+                    return OpensshPrivateKey.Read(reader.BaseStream, publicKey);
                 }
 
                 throw new FormatException("unsupported private key format");


### PR DESCRIPTION
If a separate public key has been provided to `SshPrivateKey.Read()` it should always be used even if the private key format includes a public key. This enables usage of the public key even for private key file formats which encrypt the public key.

Addresses https://github.com/dlech/KeeAgent/pull/365#issuecomment-1267193110