### PR TITLE
implement reading comment from openssh private key

### DIFF
--- a/SshAgentLib/IAgent.cs
+++ b/SshAgentLib/IAgent.cs
@@ -108,8 +108,15 @@ namespace dlech.SshAgentLib
                 throw new FileNotFoundException("this key requires a .pub file");
             }
 
-            var comment = publicKey.Comment;
-            var decryptedKey = privateKey.Decrypt(getPassPhraseCallback, progress, newComment => comment = newComment);
+            var decryptedKey = privateKey.Decrypt(getPassPhraseCallback, progress, out var comment);
+
+            // prefer public key comment if there is one, otherwise fall back
+            // to private key comment
+            if (!string.IsNullOrWhiteSpace(publicKey.Comment))
+            {
+                comment = publicKey.Comment;
+            }
+
             var key = new SshKey(
                 publicKey.Parameter,
                 decryptedKey,

--- a/SshAgentLib/IAgent.cs
+++ b/SshAgentLib/IAgent.cs
@@ -108,10 +108,12 @@ namespace dlech.SshAgentLib
                 throw new FileNotFoundException("this key requires a .pub file");
             }
 
+            var comment = publicKey.Comment;
+            var decryptedKey = privateKey.Decrypt(getPassPhraseCallback, progress, newComment => comment = newComment);
             var key = new SshKey(
                 publicKey.Parameter,
-                privateKey.Decrypt(getPassPhraseCallback, progress),
-                publicKey.Comment,
+                decryptedKey,
+                comment,
                 publicKey.Nonce,
                 publicKey.Certificate,
                 publicKey.Application

--- a/SshAgentLib/Keys/OpensshPrivateKey.cs
+++ b/SshAgentLib/Keys/OpensshPrivateKey.cs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2015,2022 David Lechner <david@lechnology.com>
+// Copyright (c) 2015,2022-2023 David Lechner <david@lechnology.com>
 
 using System;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using dlech.SshAgentLib;
-using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Security;
 using Org.BouncyCastle.Utilities.IO.Pem;
@@ -126,7 +125,11 @@ namespace SshAgentLib.Keys
             var publicKeyBlob = parser.ReadBlob();
             var privateKeyBlob = parser.ReadBlob();
 
-            SshPrivateKey.DecryptFunc decrypt = (getPassphrase, progress, updateComment) =>
+            SshPrivateKey.DecryptFunc decrypt = (
+                SshPrivateKey.GetPassphraseFunc getPassphrase,
+                IProgress<double> progress,
+                out string comment
+            ) =>
             {
                 var keyAndIV = new byte[32 + 16];
 
@@ -210,8 +213,7 @@ namespace SshAgentLib.Keys
                     out var application
                 );
                 var privateKey = privateKeyParser.ReadSsh2KeyData(publicKey);
-                var comment = privateKeyParser.ReadString();
-                updateComment?.Invoke(comment);
+                comment = privateKeyParser.ReadString();
                 // TODO: should we throw if nonce/cert is not null?
                 // TODO: do we expect application?
 

--- a/SshAgentLib/Keys/OpensshPrivateKey.cs
+++ b/SshAgentLib/Keys/OpensshPrivateKey.cs
@@ -126,7 +126,7 @@ namespace SshAgentLib.Keys
             var publicKeyBlob = parser.ReadBlob();
             var privateKeyBlob = parser.ReadBlob();
 
-            SshPrivateKey.DecryptFunc decrypt = (getPassphrase, progress) =>
+            SshPrivateKey.DecryptFunc decrypt = (getPassphrase, progress, updateComment) =>
             {
                 var keyAndIV = new byte[32 + 16];
 
@@ -210,8 +210,8 @@ namespace SshAgentLib.Keys
                     out var application
                 );
                 var privateKey = privateKeyParser.ReadSsh2KeyData(publicKey);
-                // var comment = privateKeyParser.ReadString();
-                // TODO: what to do with comment?
+                var comment = privateKeyParser.ReadString();
+                updateComment?.Invoke(comment);
                 // TODO: should we throw if nonce/cert is not null?
                 // TODO: do we expect application?
 

--- a/SshAgentLib/Keys/PemPrivateKey.cs
+++ b/SshAgentLib/Keys/PemPrivateKey.cs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2022 David Lechner <david@lechnology.com>
+// Copyright (c) 2022-2023 David Lechner <david@lechnology.com>
 
 using System;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using dlech.SshAgentLib;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.OpenSsl;
 using Org.BouncyCastle.Utilities.IO.Pem;
@@ -33,8 +32,14 @@ namespace SshAgentLib.Keys
 
             var isEncrypted = pem.Headers.Cast<PemHeader>().Any(h => h.Name == "DEK-Info");
 
-            SshPrivateKey.DecryptFunc decrypt = (getPassphrase, progress, updateComment) =>
+            SshPrivateKey.DecryptFunc decrypt = (
+                SshPrivateKey.GetPassphraseFunc getPassphrase,
+                IProgress<double> progress,
+                out string comment
+            ) =>
             {
+                comment = "";
+
                 var keyPair = ReadKeyPair(new StringReader(contents), getPassphrase);
 
                 // REVISIT: should we validate match with public key?

--- a/SshAgentLib/Keys/PemPrivateKey.cs
+++ b/SshAgentLib/Keys/PemPrivateKey.cs
@@ -33,7 +33,7 @@ namespace SshAgentLib.Keys
 
             var isEncrypted = pem.Headers.Cast<PemHeader>().Any(h => h.Name == "DEK-Info");
 
-            SshPrivateKey.DecryptFunc decrypt = (getPassphrase, progress) =>
+            SshPrivateKey.DecryptFunc decrypt = (getPassphrase, progress, updateComment) =>
             {
                 var keyPair = ReadKeyPair(new StringReader(contents), getPassphrase);
 

--- a/SshAgentLib/Keys/PuttyPrivateKey.cs
+++ b/SshAgentLib/Keys/PuttyPrivateKey.cs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2012-2013,2015,2017,2022 David Lechner <david@lechnology.com>
+// Copyright (c) 2012-2013,2015,2017,2022-2023 David Lechner <david@lechnology.com>
 
 using System;
 using System.Collections.Generic;
@@ -155,8 +155,14 @@ namespace SshAgentLib.Keys
                 reader.ReadHeader(version == "1" ? HeaderKey.PrivateHash : HeaderKey.PrivateMAC)
             );
 
-            SshPrivateKey.DecryptFunc decrypt = (getPassphrase, progress, updateComment) =>
+            SshPrivateKey.DecryptFunc decrypt = (
+                SshPrivateKey.GetPassphraseFunc getPassphrase,
+                IProgress<double> progress,
+                out string comment2
+            ) =>
             {
+                comment2 = comment;
+
                 byte[] decryptedPrivateKeyBlob;
                 byte[] macKey;
 

--- a/SshAgentLib/Keys/PuttyPrivateKey.cs
+++ b/SshAgentLib/Keys/PuttyPrivateKey.cs
@@ -155,7 +155,7 @@ namespace SshAgentLib.Keys
                 reader.ReadHeader(version == "1" ? HeaderKey.PrivateHash : HeaderKey.PrivateMAC)
             );
 
-            SshPrivateKey.DecryptFunc decrypt = (getPassphrase, progress) =>
+            SshPrivateKey.DecryptFunc decrypt = (getPassphrase, progress, updateComment) =>
             {
                 byte[] decryptedPrivateKeyBlob;
                 byte[] macKey;

--- a/SshAgentLib/Keys/SshPrivateKey.cs
+++ b/SshAgentLib/Keys/SshPrivateKey.cs
@@ -1,3 +1,4 @@
+
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2022 David Lechner <david@lechnology.com>
 
@@ -24,8 +25,15 @@ namespace SshAgentLib.Keys
         /// <returns>The decrypted parameters.</returns>
         public delegate AsymmetricKeyParameter DecryptFunc(
             GetPassphraseFunc getPassphrase,
-            IProgress<double> progress
+            IProgress<double> progress,
+            UpdateCommentFunc updateComment
         );
+
+        /// <summary>
+        /// Called if DecryptFunc found key comment
+        /// </summary>
+        /// <param name="comment">Found comment</param>
+        public delegate void UpdateCommentFunc(string comment);
 
         private readonly DecryptFunc decrypt;
 
@@ -64,16 +72,18 @@ namespace SshAgentLib.Keys
         /// Callback to get the passphrase. Can be <c>null</c> for unencrypted keys.
         /// </param>
         /// <param name="progress">Optional progress feedback.</param>
+        /// <param name="updateComment">Optional comment feedback.</param>
         /// <returns>The decrypted private key parameters.</returns>
         /// <remarks>
         /// This can be a long running/cpu intensive operation.
         /// </remarks>
         public AsymmetricKeyParameter Decrypt(
             GetPassphraseFunc getPassphrase,
-            IProgress<double> progress = null
+            IProgress<double> progress = null,
+            UpdateCommentFunc updateComment = null
         )
         {
-            return decrypt(getPassphrase, progress);
+            return decrypt(getPassphrase, progress, updateComment);
         }
 
         /// <summary>

--- a/SshAgentLib/Keys/SshPrivateKey.cs
+++ b/SshAgentLib/Keys/SshPrivateKey.cs
@@ -1,6 +1,5 @@
-
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2022 David Lechner <david@lechnology.com>
+// Copyright (c) 2022-2023 David Lechner <david@lechnology.com>
 
 using System;
 using System.IO;
@@ -20,13 +19,16 @@ namespace SshAgentLib.Keys
         /// A callback to get the passphrase. Can be <c>null</c> if the private key is not encrypted.
         /// </param>
         /// <param name="progress">
-        /// Optional progress callback. Returns normalized progres 0 to 1.
+        /// Optional progress callback. Returns normalized progress 0 to 1.
+        /// </param>
+        /// <param name="comment">
+        /// The private key comment.
         /// </param>
         /// <returns>The decrypted parameters.</returns>
         public delegate AsymmetricKeyParameter DecryptFunc(
             GetPassphraseFunc getPassphrase,
             IProgress<double> progress,
-            UpdateCommentFunc updateComment
+            out string comment
         );
 
         /// <summary>
@@ -71,19 +73,23 @@ namespace SshAgentLib.Keys
         /// <param name="getPassphrase">
         /// Callback to get the passphrase. Can be <c>null</c> for unencrypted keys.
         /// </param>
-        /// <param name="progress">Optional progress feedback.</param>
-        /// <param name="updateComment">Optional comment feedback.</param>
+        /// <param name="progress">
+        /// Optional progress feedback.
+        /// </param>
+        /// <param name="comment">
+        /// The private key comment.
+        /// </param>
         /// <returns>The decrypted private key parameters.</returns>
         /// <remarks>
         /// This can be a long running/cpu intensive operation.
         /// </remarks>
         public AsymmetricKeyParameter Decrypt(
             GetPassphraseFunc getPassphrase,
-            IProgress<double> progress = null,
-            UpdateCommentFunc updateComment = null
+            IProgress<double> progress,
+            out string comment
         )
         {
-            return decrypt(getPassphrase, progress, updateComment);
+            return decrypt(getPassphrase, progress, out comment);
         }
 
         /// <summary>

--- a/SshAgentLibTests/Keys/OpensshPrivateKeyTests.cs
+++ b/SshAgentLibTests/Keys/OpensshPrivateKeyTests.cs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2022 David Lechner <david@lechnology.com>
+// Copyright (c) 2022-2023 David Lechner <david@lechnology.com>
 
 using System;
 using System.Text;
@@ -34,10 +34,11 @@ namespace SshAgentLibTests.Keys
             var pubKey = (RsaKeyParameters)key.PublicKey.Parameter;
             Assert.That(pubKey.Modulus, Is.EqualTo(new BigInteger(n, 16)));
 
-            var privParam = key.Decrypt(null);
+            var privParam = key.Decrypt(null, null, out var comment);
 
             Assert.That(privParam.IsPrivate);
             Assert.That(privParam, Is.TypeOf<RsaPrivateCrtKeyParameters>());
+            Assert.That(comment, Is.Empty);
 
             var privKey = (RsaPrivateCrtKeyParameters)privParam;
 
@@ -46,7 +47,7 @@ namespace SshAgentLibTests.Keys
             Assert.That(privKey.Q, Is.EqualTo(new BigInteger(q, 16)));
 
             // ensure that decrypting a second time works
-            privParam = key.Decrypt(null);
+            privParam = key.Decrypt(null, null, out comment);
             Assert.That(privParam.IsPrivate);
         }
 
@@ -69,10 +70,11 @@ namespace SshAgentLibTests.Keys
             var pubKey = (RsaKeyParameters)key.PublicKey.Parameter;
             Assert.That(pubKey.Modulus, Is.EqualTo(new BigInteger(n, 16)));
 
-            var privParam = key.Decrypt(() => Encoding.UTF8.GetBytes(pw));
+            var privParam = key.Decrypt(() => Encoding.UTF8.GetBytes(pw), null, out var comment);
 
             Assert.That(privParam.IsPrivate);
             Assert.That(privParam, Is.TypeOf<RsaPrivateCrtKeyParameters>());
+            Assert.That(comment, Is.Empty);
 
             var privKey = (RsaPrivateCrtKeyParameters)privParam;
 
@@ -81,7 +83,7 @@ namespace SshAgentLibTests.Keys
             Assert.That(privKey.Q, Is.EqualTo(new BigInteger(q, 16)));
 
             // ensure that decrypting a second time works
-            privParam = key.Decrypt(() => Encoding.UTF8.GetBytes(pw));
+            privParam = key.Decrypt(() => Encoding.UTF8.GetBytes(pw), null, out comment);
             Assert.That(privParam.IsPrivate);
         }
 
@@ -102,10 +104,11 @@ namespace SshAgentLibTests.Keys
             var pubKey = (DsaPublicKeyParameters)key.PublicKey.Parameter;
             Assert.That(pubKey.Y, Is.EqualTo(new BigInteger(pub, 16)));
 
-            var privParam = key.Decrypt(null);
+            var privParam = key.Decrypt(null, null, out var comment);
 
             Assert.That(privParam.IsPrivate);
             Assert.That(privParam, Is.TypeOf<DsaPrivateKeyParameters>());
+            Assert.That(comment, Is.Empty);
 
             var privKey = (DsaPrivateKeyParameters)privParam;
 
@@ -131,10 +134,11 @@ namespace SshAgentLibTests.Keys
             var pubKey = (DsaPublicKeyParameters)key.PublicKey.Parameter;
             Assert.That(pubKey.Y, Is.EqualTo(new BigInteger(pub, 16)));
 
-            var privParam = key.Decrypt(() => Encoding.UTF8.GetBytes(pw));
+            var privParam = key.Decrypt(() => Encoding.UTF8.GetBytes(pw), null, out var comment);
 
             Assert.That(privParam.IsPrivate);
             Assert.That(privParam, Is.TypeOf<DsaPrivateKeyParameters>());
+            Assert.That(comment, Is.Empty);
 
             var privKey = (DsaPrivateKeyParameters)privParam;
 
@@ -163,10 +167,11 @@ namespace SshAgentLibTests.Keys
             );
             Assert.That(pubKey.Q, Is.EqualTo(pubKey.Parameters.Curve.DecodePoint(Hex.Decode(pub))));
 
-            var privParam = key.Decrypt(null);
+            var privParam = key.Decrypt(null, null, out var comment);
 
             Assert.That(privParam.IsPrivate);
             Assert.That(privParam, Is.TypeOf<ECPrivateKeyParameters>());
+            Assert.That(comment, Is.Empty);
 
             var privKey = (ECPrivateKeyParameters)privParam;
 
@@ -199,10 +204,11 @@ namespace SshAgentLibTests.Keys
             );
             Assert.That(pubKey.Q, Is.EqualTo(pubKey.Parameters.Curve.DecodePoint(Hex.Decode(pub))));
 
-            var privParam = key.Decrypt(() => Encoding.UTF8.GetBytes(pw));
+            var privParam = key.Decrypt(() => Encoding.UTF8.GetBytes(pw), null, out var comment);
 
             Assert.That(privParam.IsPrivate);
             Assert.That(privParam, Is.TypeOf<ECPrivateKeyParameters>());
+            Assert.That(comment, Is.Empty);
 
             var privKey = (ECPrivateKeyParameters)privParam;
 
@@ -219,7 +225,8 @@ namespace SshAgentLibTests.Keys
 
             Assert.That(key.PublicKey.Parameter, Is.TypeOf<Ed25519PublicKeyParameters>());
 
-            var privParam = key.Decrypt(null);
+            var privParam = key.Decrypt(null, null, out var comment);
+            Assert.That(comment, Is.EqualTo("ED25519 test key #1"));
 
             Assert.That(privParam.IsPrivate);
             Assert.That(privParam, Is.TypeOf<Ed25519PrivateKeyParameters>());
@@ -237,10 +244,11 @@ namespace SshAgentLibTests.Keys
 
             Assert.That(key.PublicKey.Parameter, Is.TypeOf<Ed25519PublicKeyParameters>());
 
-            var privParam = key.Decrypt(() => Encoding.UTF8.GetBytes(pw));
+            var privParam = key.Decrypt(() => Encoding.UTF8.GetBytes(pw), null, out var comment);
 
             Assert.That(privParam.IsPrivate);
             Assert.That(privParam, Is.TypeOf<Ed25519PrivateKeyParameters>());
+            Assert.That(comment, Is.EqualTo("ED25519 test key #1"));
         }
 
         [Test]
@@ -253,10 +261,12 @@ namespace SshAgentLibTests.Keys
 
             Assert.That(key.PublicKey.Parameter, Is.TypeOf<Ed25519PublicKeyParameters>());
 
-            var privParam = key.Decrypt(null);
+            var privParam = key.Decrypt(null, null, out var comment);
 
             Assert.That(privParam.IsPrivate);
             Assert.That(privParam, Is.TypeOf<Ed25519PrivateKeyParameters>());
+            // upstream file has typo
+            Assert.That(comment, Is.EqualTo("ED25519 test key #1"));
         }
     }
 }

--- a/SshAgentLibTests/Keys/PemPrivateKeyTests.cs
+++ b/SshAgentLibTests/Keys/PemPrivateKeyTests.cs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2022 David Lechner <david@lechnology.com>
+// Copyright (c) 2022-2023 David Lechner <david@lechnology.com>
 
 using System.IO;
 using System.Text;
@@ -24,7 +24,7 @@ namespace SshAgentLibTests.Keys
             var q = ReadStringResourceFile("OpenSshTestData", $"{baseName}.param.q");
             var pw = ReadStringResourceFile("OpenSshTestData", "pw");
 
-            var suffix = isEncrypted ? "_pw" : "";
+            var suffix = isEncrypted ? "_pw" : string.Empty;
             var file = OpenResourceFile("OpenSshTestData", $"{baseName}{suffix}");
             var key = SshPrivateKey.Read(file);
 
@@ -39,8 +39,9 @@ namespace SshAgentLibTests.Keys
             // decrypt multiple times to check for state corruption
             for (int i = 0; i < 2; i++)
             {
-                var privParam = key.Decrypt(getPassphrase);
+                var privParam = key.Decrypt(getPassphrase, null, out var comment);
                 Assert.That(privParam, Is.TypeOf<RsaPrivateCrtKeyParameters>());
+                Assert.That(comment, Is.Empty);
 
                 var rsa = (RsaPrivateCrtKeyParameters)privParam;
                 Assert.That(rsa.Modulus, Is.EqualTo(new BigInteger(n, 16)));
@@ -56,7 +57,7 @@ namespace SshAgentLibTests.Keys
             var priv = ReadStringResourceFile("OpenSshTestData", $"{baseName}.param.priv");
             var pw = ReadStringResourceFile("OpenSshTestData", "pw");
 
-            var suffix = isEncrypted ? "_pw" : "";
+            var suffix = isEncrypted ? "_pw" : string.Empty;
             var file = OpenResourceFile("OpenSshTestData", $"{baseName}{suffix}");
             var key = SshPrivateKey.Read(file);
 
@@ -71,8 +72,9 @@ namespace SshAgentLibTests.Keys
             // decrypt multiple times to check for state corruption
             for (int i = 0; i < 2; i++)
             {
-                var privParam = key.Decrypt(getPassphrase);
+                var privParam = key.Decrypt(getPassphrase, null, out var comment);
                 Assert.That(privParam, Is.TypeOf<DsaPrivateKeyParameters>());
+                Assert.That(comment, Is.Empty);
 
                 var dsa = (DsaPrivateKeyParameters)privParam;
                 Assert.That(dsa.X, Is.EqualTo(new BigInteger(priv, 16)));
@@ -87,7 +89,7 @@ namespace SshAgentLibTests.Keys
             var priv = ReadStringResourceFile("OpenSshTestData", $"{baseName}.param.priv");
             var pw = ReadStringResourceFile("OpenSshTestData", "pw");
 
-            var suffix = isEncrypted ? "_pw" : "";
+            var suffix = isEncrypted ? "_pw" : string.Empty;
             var file = OpenResourceFile("OpenSshTestData", $"{baseName}{suffix}");
             var key = SshPrivateKey.Read(file);
 
@@ -102,8 +104,9 @@ namespace SshAgentLibTests.Keys
             // decrypt multiple times to check for state corruption
             for (int i = 0; i < 2; i++)
             {
-                var privParam = key.Decrypt(getPassphrase);
+                var privParam = key.Decrypt(getPassphrase, null, out var comment);
                 Assert.That(privParam, Is.TypeOf<ECPrivateKeyParameters>());
+                Assert.That(comment, Is.Empty);
 
                 var ecdsa = (ECPrivateKeyParameters)privParam;
                 Assert.That(ecdsa.D, Is.EqualTo(new BigInteger(priv, 16)));

--- a/SshAgentLibTests/Keys/PuttyPrivateKeyTests.cs
+++ b/SshAgentLibTests/Keys/PuttyPrivateKeyTests.cs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2022 David Lechner <david@lechnology.com>
+// Copyright (c) 2022-2023 David Lechner <david@lechnology.com>
 
 using System;
 using System.Text;
@@ -30,7 +30,7 @@ namespace SshAgentLibTests.Keys
             var p = ReadStringResourceFile("PuttyTestData", "rsa.param.p");
             var q = ReadStringResourceFile("PuttyTestData", "rsa.param.q");
 
-            var kdf = keyDerivation == null ? "" : $"-{keyDerivation}";
+            var kdf = keyDerivation == null ? string.Empty : $"-{keyDerivation}";
             var file = OpenResourceFile("PuttyTestData", $"rsa-{version}-{encryption}{kdf}.ppk");
             var key = SshPrivateKey.Read(file);
 
@@ -50,10 +50,11 @@ namespace SshAgentLibTests.Keys
                 getPassphrase = () => Encoding.UTF8.GetBytes(pw);
             }
 
-            var privParam = key.Decrypt(getPassphrase);
+            var privParam = key.Decrypt(getPassphrase, null, out var comment);
 
             Assert.That(privParam.IsPrivate);
             Assert.That(privParam, Is.TypeOf<RsaPrivateCrtKeyParameters>());
+            Assert.That(comment, Is.EqualTo("rsa-key-20220505"));
 
             var privKey = (RsaPrivateCrtKeyParameters)privParam;
 
@@ -75,7 +76,7 @@ namespace SshAgentLibTests.Keys
             var y = ReadStringResourceFile("PuttyTestData", "dsa.param.y");
             var x = ReadStringResourceFile("PuttyTestData", "dsa.param.x");
 
-            var kdf = keyDerivation == null ? "" : $"-{keyDerivation}";
+            var kdf = keyDerivation == null ? string.Empty : $"-{keyDerivation}";
             var file = OpenResourceFile("PuttyTestData", $"dsa-{version}-{encryption}{kdf}.ppk");
             var key = SshPrivateKey.Read(file);
 
@@ -95,10 +96,11 @@ namespace SshAgentLibTests.Keys
                 getPassphrase = () => Encoding.UTF8.GetBytes(pw);
             }
 
-            var privParam = key.Decrypt(getPassphrase);
+            var privParam = key.Decrypt(getPassphrase, null, out var comment);
 
             Assert.That(privParam.IsPrivate);
             Assert.That(privParam, Is.TypeOf<DsaPrivateKeyParameters>());
+            Assert.That(comment, Is.EqualTo("dsa-key-20220506"));
 
             var privKey = (DsaPrivateKeyParameters)privParam;
 
@@ -128,7 +130,7 @@ namespace SshAgentLibTests.Keys
             var q = ReadStringResourceFile("PuttyTestData", $"ecdsa-{curve}.param.q");
             var d = ReadStringResourceFile("PuttyTestData", $"ecdsa-{curve}.param.d");
 
-            var kdf = keyDerivation == null ? "" : $"-{keyDerivation}";
+            var kdf = keyDerivation == null ? string.Empty : $"-{keyDerivation}";
             var file = OpenResourceFile(
                 "PuttyTestData",
                 $"ecdsa-{curve}-{version}-{encryption}{kdf}.ppk"
@@ -154,10 +156,11 @@ namespace SshAgentLibTests.Keys
                 getPassphrase = () => Encoding.UTF8.GetBytes(pw);
             }
 
-            var privParam = key.Decrypt(getPassphrase);
+            var privParam = key.Decrypt(getPassphrase, null, out var comment);
 
             Assert.That(privParam.IsPrivate);
             Assert.That(privParam, Is.TypeOf<ECPrivateKeyParameters>());
+            Assert.That(comment, Is.EqualTo("ecdsa-key-20220506"));
 
             var privKey = (ECPrivateKeyParameters)privParam;
 
@@ -177,7 +180,7 @@ namespace SshAgentLibTests.Keys
             var pub = ReadStringResourceFile("PuttyTestData", $"eddsa-ed25519.param.pub");
             var priv = ReadStringResourceFile("PuttyTestData", $"eddsa-ed25519.param.priv");
 
-            var kdf = keyDerivation == null ? "" : $"-{keyDerivation}";
+            var kdf = keyDerivation == null ? string.Empty : $"-{keyDerivation}";
             var file = OpenResourceFile(
                 "PuttyTestData",
                 $"eddsa-ed25519-{version}-{encryption}{kdf}.ppk"
@@ -200,10 +203,11 @@ namespace SshAgentLibTests.Keys
                 getPassphrase = () => Encoding.UTF8.GetBytes(pw);
             }
 
-            var privParam = key.Decrypt(getPassphrase);
+            var privParam = key.Decrypt(getPassphrase, null, out var comment);
 
             Assert.That(privParam.IsPrivate);
             Assert.That(privParam, Is.TypeOf<Ed25519PrivateKeyParameters>());
+            Assert.That(comment, Is.EqualTo("eddsa-key-20220506"));
 
             var privKey = (Ed25519PrivateKeyParameters)privParam;
             Assert.That(privKey.GetEncoded(), Is.EqualTo(Util.FromHex(priv)));
@@ -223,7 +227,7 @@ namespace SshAgentLibTests.Keys
             var pub = ReadStringResourceFile("PuttyTestData", $"eddsa-ed448.param.pub");
             var priv = ReadStringResourceFile("PuttyTestData", $"eddsa-ed448.param.priv");
 
-            var kdf = keyDerivation == null ? "" : $"-{keyDerivation}";
+            var kdf = keyDerivation == null ? string.Empty : $"-{keyDerivation}";
             var file = OpenResourceFile(
                 "PuttyTestData",
                 $"eddsa-ed448-{version}-{encryption}{kdf}.ppk"
@@ -246,10 +250,11 @@ namespace SshAgentLibTests.Keys
                 getPassphrase = () => Encoding.UTF8.GetBytes(pw);
             }
 
-            var privParam = key.Decrypt(getPassphrase);
+            var privParam = key.Decrypt(getPassphrase, null, out var comment);
 
             Assert.That(privParam.IsPrivate);
             Assert.That(privParam, Is.TypeOf<Ed448PrivateKeyParameters>());
+            Assert.That(comment, Is.EqualTo("eddsa-key-20220506"));
 
             var privKey = (Ed448PrivateKeyParameters)privParam;
             Assert.That(privKey.GetEncoded(), Is.EqualTo(Util.FromHex(priv)));
@@ -268,7 +273,7 @@ namespace SshAgentLibTests.Keys
             );
             var key = SshPrivateKey.Read(file);
 
-            Assert.DoesNotThrow(() => key.Decrypt(getPassphrase));
+            Assert.DoesNotThrow(() => key.Decrypt(getPassphrase, null, out var comment));
         }
     }
 }

--- a/SshAgentLibTests/SshAgentLibTests.csproj
+++ b/SshAgentLibTests/SshAgentLibTests.csproj
@@ -131,7 +131,7 @@
       <Version>3.13.3</Version>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter">
-      <Version>4.3.0</Version>
+      <Version>4.3.1</Version>
     </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Reading key comment from an openssh private key, Because it's encrypted, added callback on `Decrypt`.
https://github.com/openssh/openssh-portable/blob/4a1805d532616233dd6072e5cd273b96dd3062e6/PROTOCOL.key#L38-L39

See also: https://github.com/dlech/KeeAgent/issues/375